### PR TITLE
Fix compiler errors in fuzzer logic

### DIFF
--- a/lib/fuzzer.c
+++ b/lib/fuzzer.c
@@ -27,6 +27,8 @@
 #include <string.h>
 #include "fuzi_q.h"
 
+uint8_t* fuzz_in_place_or_skip_varint(uint64_t fuzz_pilot, uint8_t* bytes, uint8_t* bytes_max, int do_fuzz);
+
 /*
  * Basic fuzz test just tries to flip some bits in random packets
  */
@@ -548,15 +550,15 @@ void new_token_frame_fuzzer(uint64_t fuzz_pilot, uint8_t* frame_start, uint8_t* 
     switch (choice) {
     case 0: // Fuzz Token Length varint with specific boundary values
         {
-            size_t space_for_token_data = (bytes_max > token_data_start) ? (bytes_max - token_data_start) : 0;
-            uint64_t target_len_val = 0;
+            // size_t space_for_token_data = (bytes_max > token_data_start) ? (bytes_max - token_data_start) : 0; // Kept for context if needed later
+            // uint64_t target_len_val = 0; // Removed as unused
             int len_choice = fuzz_pilot % 4;
             fuzz_pilot >>= 2;
 
             switch (len_choice) {
-            case 0: target_len_val = 0; break;
-            case 1: target_len_val = space_for_token_data; break;
-            case 2: target_len_val = space_for_token_data + 1; break;
+            case 0: /* target_len_val = 0; */ break; // Assignment removed
+            case 1: /* target_len_val = space_for_token_data; */ break; // Assignment removed
+            case 2: /* target_len_val = space_for_token_data + 1; */ break; // Assignment removed
             default: // Max value for current varint encoding of token_len_varint_start
                 {
                     uint8_t* temp_len_end = (uint8_t*)picoquic_frames_varint_skip(token_len_varint_start, bytes_max);


### PR DESCRIPTION
This commit addresses two compiler errors reported in `lib/fuzzer.c`:

1.  **Implicit declaration of `fuzz_in_place_or_skip_varint`**: Resolved by adding a forward function prototype for `fuzz_in_place_or_skip_varint` at the beginning of the file. This ensures its signature is known before its first call, preventing type conflicts with its later definition.

2.  **Unused variable `target_len_val` in `new_token_frame_fuzzer`**: Resolved by removing the declaration and assignments of the `target_len_val` variable within the specific code paths where it was set but not subsequently used. This occurred in the logic for fuzzing token length with specific boundary values, where some paths were simplified to use general varint fuzzing.

These corrections ensure the fuzzer code compiles cleanly with warnings treated as errors.