### PR TITLE
Fix: Correct CRYPTO frame type constant in fuzzer_frames

### DIFF
--- a/lib/fuzzer_frames.c
+++ b/lib/fuzzer_frames.c
@@ -389,19 +389,19 @@ static uint8_t test_frame_type_crypto_hs_alt[] = {
 };
 
 static uint8_t test_frame_crypto_zero_len[] = {
-    picoquic_frame_type_crypto, 0x00, 0x00
+    picoquic_frame_type_crypto_hs, 0x00, 0x00
 };
 
 static uint8_t test_frame_crypto_large_offset[] = {
-    picoquic_frame_type_crypto, 0x50, 0x00, 0x05, 'd','u','m','m','y'
+    picoquic_frame_type_crypto_hs, 0x50, 0x00, 0x05, 'd','u','m','m','y'
 };
 
 static uint8_t test_frame_crypto_fragment1[] = {
-    picoquic_frame_type_crypto, 0x00, 0x05, 'H','e','l','l','o'
+    picoquic_frame_type_crypto_hs, 0x00, 0x05, 'H','e','l','l','o'
 };
 
 static uint8_t test_frame_crypto_fragment2[] = {
-    picoquic_frame_type_crypto, 0x05, 0x05, 'W','o','r','l','d'
+    picoquic_frame_type_crypto_hs, 0x05, 0x05, 'W','o','r','l','d'
 };
 
 static uint8_t test_frame_type_retire_connection_id[] = {


### PR DESCRIPTION
I replaced uses of the undeclared constant 'picoquic_frame_type_crypto' with the correct 'picoquic_frame_type_crypto_hs' in the definitions of test_frame_crypto_zero_len, test_frame_crypto_large_offset, test_frame_crypto_fragment1, and test_frame_crypto_fragment2 in lib/fuzzer_frames.c.

This resolves a compilation error where 'picoquic_frame_type_crypto' was not recognized.