### PR TITLE
Fix: Add missing nb_header_fuzzed field to fuzzer_ctx_t

### DIFF
--- a/include/fuzi_q.h
+++ b/include/fuzi_q.h
@@ -105,6 +105,7 @@ typedef struct st_fuzzer_ctx_t {
     uint32_t nb_packets;
     uint32_t nb_fuzzed;
     uint32_t nb_fuzzed_length;
+    uint32_t nb_header_fuzzed;
 } fuzzer_ctx_t;
 
 fuzzer_icid_ctx_t* fuzzer_get_icid_ctx(fuzzer_ctx_t* ctx, picoquic_connection_id_t* icid, uint64_t current_time);


### PR DESCRIPTION
The compiler was reporting an error because the `nb_header_fuzzed` field was being used in `lib/fuzzer.c` but was not defined in the `fuzzer_ctx_t` struct in `include/fuzi_q.h`.

This commit adds the `uint32_t nb_header_fuzzed;` field to the `fuzzer_ctx_t` struct to resolve the compilation error. This field is intended to count the number of times packet headers are fuzzed.